### PR TITLE
Fix breakpoint hook type errors

### DIFF
--- a/.changeset/lucky-numbers-tan.md
+++ b/.changeset/lucky-numbers-tan.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Fix type errors in breakpoint hooks preventing type declaration file emission

--- a/src/lib/hooks/useBreakpoint/useBreakpoint.tsx
+++ b/src/lib/hooks/useBreakpoint/useBreakpoint.tsx
@@ -38,7 +38,7 @@ const useBreakpoint = ({ fallback = "base" }: Options = {}) => {
     handleResize();
 
     // create tuple mapping of semantic breakpoint keys with their values
-    const range = Object.entries(breakpoints)
+    const range = Object.entries(breakpoints!)
       .map(([key, breakpoint]) => [key, emToPx(breakpoint as `${number}em`)])
       // reverse to set largest breakpoint at the start (top-down; decreasing order)
       .reverse();

--- a/src/lib/hooks/useBreakpointValue/useBreakpointValue.tsx
+++ b/src/lib/hooks/useBreakpointValue/useBreakpointValue.tsx
@@ -11,7 +11,7 @@ import type { BreakpointToken } from "generated/panda/tokens";
  * @returns The closest value to the current breakpoint.
  */
 const getClosestValue = <T,>(values: Record<string, T>, breakpoint: string) => {
-  const breakpoints = Object.keys(defaultBreakpoints);
+  const breakpoints = Object.keys(defaultBreakpoints!);
 
   let index = Object.keys(values).indexOf(breakpoint);
 


### PR DESCRIPTION
## Description

##### Task link: N/A

- Fixed type errors in breakpoint hooks preventing type declaration file emission

## Test Steps

- Verify build includes type declaration (`.d.ts`) files
