### PR TITLE
Conditionally render triggers

### DIFF
--- a/.changeset/odd-rockets-know.md
+++ b/.changeset/odd-rockets-know.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Made trigger-enabled components conditionally render trigger only if passed (`Drawer`, `HoverCard`, `Menu`, `Popover`, `Tooltip`)

--- a/.changeset/sixty-flies-marry.md
+++ b/.changeset/sixty-flies-marry.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Update style recipes for accordion, checkbox, dialog, and drawer

--- a/.changeset/tough-bulldogs-compare.md
+++ b/.changeset/tough-bulldogs-compare.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Improve ability to customize and compose `Accordion`

--- a/src/components/core/Accordion/Accordion.stories.tsx
+++ b/src/components/core/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import { Accordion } from "components";
+import { Accordion, Button } from "components";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -25,6 +25,11 @@ export const Default: Story = {
         title: "Extended Reality",
         body: "Extended Reality (XR) is a marketing term used to represent the spectrum of virtual reality (VR) and augmented reality (AR) technologies.",
       },
+      {
+        isDisabled: true,
+        title: "Mixed Reality",
+        body: "Mixed reality (MR) is a marketing term coined by Microsoft and occasionally used by other companies to describe a technology that blends real and virtual worlds to produce new environments and visualizations where physical and digital objects coexist and interact in real time.",
+      },
     ],
   },
 };
@@ -35,7 +40,20 @@ export const Default: Story = {
 export const DefaultOpen: Story = {
   args: {
     ...Default.args,
-    defaultValue: [Default.args.items[0].title],
+    defaultValue: [Default.args.items[0].title!.toString()],
+  },
+};
+
+export const CustomTitle: Story = {
+  args: {
+    ...Default.args,
+    items: [
+      {
+        ...Default.args.items[0],
+        title: <Button bgColor="red">{Default.args.items[0].title}</Button>,
+      },
+      ...Default.args.items.slice(1),
+    ],
   },
 };
 

--- a/src/components/core/Accordion/Accordion.tsx
+++ b/src/components/core/Accordion/Accordion.tsx
@@ -5,7 +5,10 @@ import { styled } from "generated/panda/jsx";
 import { accordion, type AccordionVariantProps } from "generated/panda/recipes";
 import { createStyleContext } from "lib/util";
 
-import type { AccordionProps as ArkAccordionProps } from "@ark-ui/react/accordion";
+import type {
+  AccordionItemProps as ArkAccordionItemProps,
+  AccordionProps as ArkAccordionProps,
+} from "@ark-ui/react/accordion";
 // https://github.com/microsoft/TypeScript/issues/47663
 import type {} from "@zag-js/accordion";
 import type { ReactNode } from "react";
@@ -15,11 +18,21 @@ const { withProvider, withContext } = createStyleContext(accordion);
 export interface AccordionProps
   extends ArkAccordionProps,
     AccordionVariantProps {
-  items: {
-    // TODO use `ReactNode` for title
-    title: string;
+  items: (Omit<ArkAccordionItemProps, "title" | "value"> & {
+    /** Title of item. */
+    title: ReactNode;
+    /** Content to display when item is open. */
     body: ReactNode;
-  }[];
+    /** Whether item is disabled. */
+    isDisabled?: boolean;
+    // TODO enable support for below prop extensions
+    /** Item trigger props. */
+    // triggerProps?: ArkAccordionItemContentProps;
+    /** Item icon props. */
+    // iconProps?: AccordionIconProps;
+    /** Item content props. */
+    // contentProps?: ArkAccordionItemTriggerProps;
+  })[];
 }
 
 export const AccordionRoot = withProvider(styled(ArkAccordion.Root), "root");
@@ -40,13 +53,21 @@ export const AccordionItemTrigger = withContext(
   "itemTrigger",
 );
 
-const AccordionIcon = (props: { isOpen: boolean }) => {
+interface AccordionIconProps {
+  isOpen: boolean;
+}
+
+/**
+ * Accordion icon intended to be used to indicate whether an accordion item is open or closed.
+ */
+const AccordionIcon = ({ isOpen }: AccordionIconProps) => {
   const iconStyles = {
-    transform: props.isOpen ? "rotate(-180deg)" : undefined,
+    transform: isOpen ? "rotate(-180deg)" : undefined,
     transition: "transform 0.2s",
     transformOrigin: "center",
   };
 
+  // TODO allow custom icon overrides (make sure animation still works well)
   return <FiChevronDown style={iconStyles} />;
 };
 
@@ -55,8 +76,13 @@ const AccordionIcon = (props: { isOpen: boolean }) => {
  */
 const Accordion = ({ items, ...rest }: AccordionProps) => (
   <AccordionRoot multiple {...rest}>
-    {items.map(({ title, body }) => (
-      <AccordionItem key={title} value={title}>
+    {items.map(({ title, body, isDisabled, ...rest }) => (
+      <AccordionItem
+        key={title!.toString()}
+        value={title!.toString()}
+        disabled={isDisabled}
+        {...rest}
+      >
         {({ isOpen }) => (
           <>
             <AccordionItemTrigger>
@@ -66,6 +92,7 @@ const Accordion = ({ items, ...rest }: AccordionProps) => (
 
             <AccordionItemContent>
               {/* NB: div wrapper enforces body content to collapse properly if, for example, a string is passed */}
+              {/* TODO remove wrapper, see https://github.com/cschroeter/park-ui/issues/92#event-10971243692 */}
               <div>{body}</div>
             </AccordionItemContent>
           </>

--- a/src/components/core/Dialog/Dialog.stories.tsx
+++ b/src/components/core/Dialog/Dialog.stories.tsx
@@ -1,5 +1,6 @@
 import { Button, Dialog, DialogCloseTrigger } from "components";
 import { Stack } from "generated/panda/jsx";
+import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -13,7 +14,7 @@ const meta = {
 
 export const Default: Story = {
   args: {
-    trigger: <Button variant="outline">Open dialog</Button>,
+    trigger: <Button>Open Dialog</Button>,
     title: "Dialog Title",
     description: "Dialog Description",
     children: (
@@ -40,6 +41,35 @@ export const LazyMount: Story = {
     ...Default.args,
     lazyMount: true,
     unmountOnExit: true,
+  },
+};
+
+/**
+ * Dialog with no trigger; controlled by decoupled external state.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    trigger: undefined,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (
+      <>
+        <Button onClick={onOpen}>Open Dialog (Controlled)</Button>
+
+        <Dialog
+          open={isOpen}
+          onOpenChange={({ open }) => (open ? onOpen() : onClose())}
+          title={args.title}
+          description={args.description}
+        >
+          {args.children}
+        </Dialog>
+      </>
+    );
   },
 };
 

--- a/src/components/core/Dialog/Dialog.tsx
+++ b/src/components/core/Dialog/Dialog.tsx
@@ -66,7 +66,7 @@ const Dialog = ({
   <DialogRoot {...rest}>
     {(ctx) => (
       <>
-        <DialogTrigger>{trigger}</DialogTrigger>
+        {trigger && <DialogTrigger>{trigger}</DialogTrigger>}
 
         <Portal>
           <DialogBackdrop />

--- a/src/components/core/Drawer/Drawer.stories.tsx
+++ b/src/components/core/Drawer/Drawer.stories.tsx
@@ -2,6 +2,7 @@ import { FiArrowRight } from "react-icons/fi/index.js";
 
 import { Button, Drawer, DrawerCloseTrigger, Input, Label } from "components";
 import { Stack } from "generated/panda/jsx";
+import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -15,7 +16,7 @@ const meta = {
 
 export const Default: Story = {
   args: {
-    trigger: <Button variant="outline">Open Drawer</Button>,
+    trigger: <Button>Open Drawer</Button>,
     title: "Drawer Title",
     description: "Drawer description",
     footerProps: { gap: 3 },
@@ -46,6 +47,35 @@ export const Default: Story = {
         </DrawerCloseTrigger>
       </>
     ),
+  },
+};
+
+/**
+ * Drawer with no trigger; controlled by decoupled external state.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    trigger: undefined,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (
+      <>
+        <Button onClick={onOpen}>Open Drawer (Controlled)</Button>
+
+        <Drawer
+          open={isOpen}
+          onOpenChange={({ open }) => (open ? onOpen() : onClose())}
+          title={args.title}
+          description={args.description}
+        >
+          {args.children}
+        </Drawer>
+      </>
+    );
   },
 };
 

--- a/src/components/core/Drawer/Drawer.tsx
+++ b/src/components/core/Drawer/Drawer.tsx
@@ -76,7 +76,7 @@ const Drawer = ({
   <DrawerRoot {...rest}>
     {(ctx) => (
       <>
-        <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+        {trigger && <DrawerTrigger asChild>{trigger}</DrawerTrigger>}
 
         <Portal>
           <DrawerBackdrop />

--- a/src/components/core/FileUpload/FileUpload.tsx
+++ b/src/components/core/FileUpload/FileUpload.tsx
@@ -30,19 +30,19 @@ export interface FileUploadProps
   label?: ReactNode;
   /** File upload dialog trigger. */
   dialogTrigger?: ReactNode;
-  /** Props for the file upload dropzone. */
+  /** File upload dropzone props. */
   dropzoneProps?: ArkFileUploadDropzoneProps;
-  /** Props for the file upload item group. */
+  /** File upload item group props. */
   itemGroupProps?: ArkFileUploadItemGroupProps;
-  /** Props for the file upload item. */
+  /** File upload item props. */
   itemProps?: ArkFileUploadItemProps;
-  /** Props for the file upload item preview. */
+  /** File upload item preview props. */
   itemPreviewProps?: ArkFileUploadItemPreviewProps;
-  /** Props for the file upload item name. */
+  /** File upload item name props. */
   itemNameProps?: ArkFileUploadItemNameProps;
-  /** Props for the file upload item size text. */
+  /** File upload item size text props. */
   itemSizeTextProps?: ArkFileUploadItemSizeTextProps;
-  /** Props for the file upload item delete trigger. */
+  /** File upload item delete trigger props. */
   itemDeleteTriggerProps?: ArkFileUploadItemDeleteTriggerProps;
 }
 

--- a/src/components/core/HoverCard/HoverCard.stories.tsx
+++ b/src/components/core/HoverCard/HoverCard.stories.tsx
@@ -1,8 +1,9 @@
 import { FiMapPin } from "react-icons/fi/index.js";
 
-import { Avatar, HoverCard, Text } from "components";
+import { Avatar, Button, HoverCard, Text } from "components";
 import { HStack, Stack, styled } from "generated/panda/jsx";
 import { app } from "lib/config";
+import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -49,6 +50,33 @@ export const Default: Story = {
         </Stack>
       </Stack>
     ),
+  },
+};
+
+/**
+ * Hover card with no trigger; controlled by decoupled external state.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    trigger: undefined,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (
+      <>
+        <Button onClick={onOpen}>Open Hover card (Controlled)</Button>
+
+        <HoverCard
+          open={isOpen}
+          onOpenChange={({ open }) => (open ? onOpen() : onClose())}
+        >
+          {args.children}
+        </HoverCard>
+      </>
+    );
   },
 };
 

--- a/src/components/core/HoverCard/HoverCard.tsx
+++ b/src/components/core/HoverCard/HoverCard.tsx
@@ -48,7 +48,7 @@ const HoverCard = ({ trigger, children, ...rest }: HoverCardProps) => (
   <HoverCardRoot openDelay={0} closeDelay={100} {...rest}>
     {(ctx) => (
       <>
-        <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>
+        {trigger && <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>}
 
         <Portal>
           <HoverCardPositioner>

--- a/src/components/core/Menu/Menu.stories.tsx
+++ b/src/components/core/Menu/Menu.stories.tsx
@@ -26,6 +26,7 @@ import {
   Text,
 } from "components";
 import { HStack } from "generated/panda/jsx";
+import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -39,7 +40,7 @@ const meta = {
 
 export const Default: Story = {
   args: {
-    trigger: <Button variant="outline">Open menu</Button>,
+    trigger: <Button variant="outline">Open Menu</Button>,
     children: (
       <MenuItemGroup id="group-1">
         <MenuItemGroupLabel htmlFor="group-1">My Account</MenuItemGroupLabel>
@@ -123,6 +124,33 @@ export const Default: Story = {
         </MenuItem>
       </MenuItemGroup>
     ),
+  },
+};
+
+/**
+ * Menu with no trigger; controlled by decoupled external state.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    trigger: undefined,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (
+      <>
+        <Button onClick={onOpen}>Open Menu (Controlled)</Button>
+
+        <Menu
+          open={isOpen}
+          onOpenChange={({ open }) => (open ? onOpen() : onClose())}
+        >
+          {args.children}
+        </Menu>
+      </>
+    );
   },
 };
 

--- a/src/components/core/Menu/Menu.tsx
+++ b/src/components/core/Menu/Menu.tsx
@@ -73,7 +73,7 @@ const Menu = ({ trigger, children, ...rest }: MenuProps) => (
   <MenuRoot {...rest}>
     {(ctx) => (
       <>
-        <MenuTrigger asChild>{trigger}</MenuTrigger>
+        {trigger && <MenuTrigger asChild>{trigger}</MenuTrigger>}
 
         <Portal>
           <MenuPositioner>

--- a/src/components/core/Popover/Popover.stories.tsx
+++ b/src/components/core/Popover/Popover.stories.tsx
@@ -1,4 +1,5 @@
 import { Button, Popover } from "components";
+import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -12,9 +13,36 @@ const meta = {
 
 export const Default: Story = {
   args: {
-    trigger: <Button variant="outline">Open Popover</Button>,
+    trigger: <Button>Open Popover</Button>,
     title: "Hello",
     description: "I'm a popover! I pop all over the place.",
+  },
+};
+
+/**
+ * Popover with no trigger; controlled by decoupled external state.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    trigger: undefined,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (
+      <>
+        <Button onClick={onOpen}>Open Popover (Controlled)</Button>
+
+        <Popover
+          open={isOpen}
+          onOpenChange={({ open }) => (open ? onOpen() : onClose())}
+          title={args.title}
+          description={args.description}
+        />
+      </>
+    );
   },
 };
 

--- a/src/components/core/Popover/Popover.tsx
+++ b/src/components/core/Popover/Popover.tsx
@@ -72,7 +72,7 @@ const Popover = ({
   ...rest
 }: PopoverProps) => (
   <PopoverRoot portalled {...rest}>
-    <PopoverTrigger>{trigger}</PopoverTrigger>
+    {trigger && <PopoverTrigger>{trigger}</PopoverTrigger>}
 
     <Portal>
       <PopoverPositioner>

--- a/src/components/core/Tooltip/Tooltip.stories.tsx
+++ b/src/components/core/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,5 @@
-import { Tooltip } from "components";
+import { Button, Tooltip } from "components";
+import { useDisclosure } from "lib/hooks";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -14,6 +15,32 @@ export const Default: Story = {
   args: {
     trigger: "Hover over me!",
     content: "I'm a tooltip!",
+  },
+};
+
+/**
+ * Tooltip with no trigger; controlled by decoupled external state.
+ */
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    trigger: undefined,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (
+      <>
+        <Button onClick={onOpen}>Open Tooltip (Controlled)</Button>
+
+        <Tooltip
+          open={isOpen}
+          onOpenChange={({ open }) => (open ? onOpen() : onClose())}
+          content={args.content}
+        />
+      </>
+    );
   },
 };
 

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -45,7 +45,7 @@ export const TooltipTrigger = withContext(
  */
 const Tooltip = ({ trigger, content, ...rest }: TooltipProps) => (
   <TooltipRoot {...rest}>
-    <TooltipTrigger>{trigger}</TooltipTrigger>
+    {trigger && <TooltipTrigger>{trigger}</TooltipTrigger>}
 
     <Portal>
       <TooltipPositioner>

--- a/src/lib/theme/extensions/slotRecipes/accordion.slotRecipe.ts
+++ b/src/lib/theme/extensions/slotRecipes/accordion.slotRecipe.ts
@@ -25,6 +25,10 @@ const accordion = defineSlotRecipe({
       textStyle: "lg",
       textAlign: "left",
       width: "full",
+      _disabled: {
+        color: "foreground.disabled",
+        cursor: "not-allowed",
+      },
     },
     itemIndicator: {
       color: "foreground.muted",

--- a/src/lib/theme/extensions/slotRecipes/checkbox.slotRecipe.ts
+++ b/src/lib/theme/extensions/slotRecipes/checkbox.slotRecipe.ts
@@ -46,6 +46,14 @@ const checkbox = defineSlotRecipe({
           bgColor: "accent.default",
         },
       },
+      "&:has(+ :focus-visible)": {
+        outlineOffset: "2px",
+        outline: "2px solid",
+        outlineColor: "border.outline",
+        _checked: {
+          outlineColor: "border.accent",
+        },
+      },
     },
   },
   defaultVariants: {

--- a/src/lib/theme/extensions/slotRecipes/dialog.slotRecipe.ts
+++ b/src/lib/theme/extensions/slotRecipes/dialog.slotRecipe.ts
@@ -15,8 +15,11 @@ const dialog = defineSlotRecipe({
         base: "white.800a",
         _dark: "black.800a",
       },
-      inset: 0,
+      height: "100vh",
+      left: 0,
       position: "fixed",
+      top: 0,
+      width: "100vw",
       zIndex: "overlay",
       _open: {
         animation: "backdrop-in",
@@ -28,9 +31,13 @@ const dialog = defineSlotRecipe({
     positioner: {
       alignItems: "center",
       display: "flex",
-      inset: 0,
       justifyContent: "center",
+      left: 0,
+      overflow: "auto",
       position: "fixed",
+      top: 0,
+      width: "100vw",
+      height: "100dvh",
       zIndex: "modal",
     },
     content: {

--- a/src/lib/theme/extensions/slotRecipes/drawer.slotRecipe.ts
+++ b/src/lib/theme/extensions/slotRecipes/drawer.slotRecipe.ts
@@ -17,8 +17,11 @@ const drawer = defineSlotRecipe({
         base: "white.800a",
         _dark: "black.800a",
       },
-      inset: 0,
+      height: "100vh",
+      left: 0,
       position: "fixed",
+      top: 0,
+      width: "100vw",
       zIndex: "overlay",
       _open: {
         animation: "backdrop-in",
@@ -30,11 +33,11 @@ const drawer = defineSlotRecipe({
     positioner: {
       alignItems: "center",
       display: "flex",
-      top: 0,
-      bottom: 0,
+      height: "100dvh",
       justifyContent: "center",
       position: "fixed",
-      width: { base: "full", sm: "sm" },
+      top: 0,
+      width: { base: "100vw", sm: "sm" },
       zIndex: "modal",
     },
     content: {


### PR DESCRIPTION
## Description

##### Task link: https://trello.com/c/1Op3IEXM/39-make-all-triggers-optional

- Made all trigger-enabled components conditionally render trigger only if it is passed, to accommodate the ability to control state externally
- Updated recipe styles
- Made customizing and composing `Accordion` easier

## Test Steps

- Test trigger-enabled components to make sure they work well without a trigger passed