### PR TITLE
fix `Dialog` DOM nesting validation

### DIFF
--- a/.changeset/sixty-cameras-design.md
+++ b/.changeset/sixty-cameras-design.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Fix `Dialog` DOM nesting validation by adding `asChild` prop to triggers

--- a/src/components/core/Dialog/Dialog.tsx
+++ b/src/components/core/Dialog/Dialog.tsx
@@ -77,7 +77,7 @@ const Dialog = ({
   <DialogRoot {...rest}>
     {(ctx) => (
       <>
-        {trigger && <DialogTrigger>{trigger}</DialogTrigger>}
+        {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
 
         <DialogBackdrop />
 
@@ -99,7 +99,7 @@ const Dialog = ({
               {getContextualChildren({ ctx, children })}
             </Stack>
 
-            <DialogCloseTrigger position="absolute" top={2} right={2}>
+            <DialogCloseTrigger asChild position="absolute" top={2} right={2}>
               <Button aria-label="Close dialog" variant="ghost" size="sm">
                 <FiX />
               </Button>


### PR DESCRIPTION
## Description

##### Task link: N/A

- Corrected nesting to pass DOM validation

## Test Steps

- Verify a rendered `Dialog` component does not result in DOM validation console errors
- Verify `Dialog` triggers function correctly