### PR TITLE
`TagsInput` clear trigger composition

### DIFF
--- a/.changeset/selfish-carpets-help.md
+++ b/.changeset/selfish-carpets-help.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Remove close trigger wrapper on `Drawer` and `Popover`

--- a/.changeset/seven-rings-invent.md
+++ b/.changeset/seven-rings-invent.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Allow overriding `TagsInput` clear trigger render

--- a/src/components/core/Drawer/Drawer.tsx
+++ b/src/components/core/Drawer/Drawer.tsx
@@ -1,11 +1,6 @@
 import { ark } from "@ark-ui/react";
 import { Dialog as ArkDialog } from "@ark-ui/react/dialog";
-import {
-  cloneElement,
-  type ComponentProps,
-  type ReactElement,
-  type ReactNode,
-} from "react";
+import { type ComponentProps, type ReactElement, type ReactNode } from "react";
 import { FiX } from "react-icons/fi";
 
 import Button from "components/core/Button/Button";
@@ -110,11 +105,9 @@ const Drawer = ({
   description,
   footer,
   closeTrigger = (
-    <DrawerCloseTrigger asChild position="absolute" top={3} right={4}>
-      <Button variant="ghost">
-        <FiX />
-      </Button>
-    </DrawerCloseTrigger>
+    <Button variant="ghost">
+      <FiX />
+    </Button>
   ),
   children,
   triggerProps,
@@ -150,7 +143,17 @@ const Drawer = ({
               </DrawerDescription>
             )}
 
-            {closeTrigger && cloneElement(closeTrigger, closeTriggerProps)}
+            {closeTrigger && (
+              <DrawerCloseTrigger
+                asChild
+                position="absolute"
+                top={3}
+                right={4}
+                {...closeTriggerProps}
+              >
+                {closeTrigger}
+              </DrawerCloseTrigger>
+            )}
           </DrawerHeader>
         )}
 

--- a/src/components/core/Popover/Popover.tsx
+++ b/src/components/core/Popover/Popover.tsx
@@ -1,10 +1,5 @@
 import { Popover as ArkPopover } from "@ark-ui/react/popover";
-import {
-  cloneElement,
-  type ReactElement,
-  type ComponentProps,
-  type ReactNode,
-} from "react";
+import { type ReactElement, type ComponentProps, type ReactNode } from "react";
 import { FiX } from "react-icons/fi";
 
 import Button from "components/core/Button/Button";
@@ -113,13 +108,9 @@ const Popover = ({
   children,
   // TODO make default close trigger styles more flexible, doesn't always look good with certain titles, descriptions, nor children
   closeTrigger = (
-    <Box position="absolute" top="1" right="1">
-      <PopoverCloseTrigger asChild>
-        <Button aria-label="Close popover" variant="ghost" size="sm">
-          <FiX />
-        </Button>
-      </PopoverCloseTrigger>
-    </Box>
+    <Button aria-label="Close popover" variant="ghost" size="sm">
+      <FiX />
+    </Button>
   ),
   triggerProps,
   positionerProps,
@@ -150,7 +141,17 @@ const Popover = ({
           <Box mt={2}>{children}</Box>
         </Stack>
 
-        {closeTrigger && cloneElement(closeTrigger, closeTriggerProps)}
+        {closeTrigger && (
+          <PopoverCloseTrigger
+            asChild
+            position="absolute"
+            top="1"
+            right="1"
+            {...closeTriggerProps}
+          >
+            {closeTrigger}
+          </PopoverCloseTrigger>
+        )}
       </PopoverContent>
     </PopoverPositioner>
   </PopoverRoot>

--- a/src/components/core/TagsInput/TagsInput.stories.tsx
+++ b/src/components/core/TagsInput/TagsInput.stories.tsx
@@ -14,7 +14,14 @@ const meta = {
 export const Default: Story = {
   args: {
     maxW: "xs",
-    label: "Fruits (click tags to edit)",
+    label: "Fruits (double click tags to edit)",
+  },
+};
+
+export const NoClearTrigger: Story = {
+  args: {
+    ...Default.args,
+    clearTrigger: null,
   },
 };
 

--- a/src/components/core/TagsInput/TagsInput.tsx
+++ b/src/components/core/TagsInput/TagsInput.tsx
@@ -75,6 +75,8 @@ export interface TagsInputLabelProps
 export interface TagsInputProps extends TagsInputRootProps {
   /** Input label. */
   label?: ReactNode;
+  /** Clear trigger. Defaults to a button. */
+  clearTrigger?: ReactNode;
   /** Label props. */
   labelProps?: TagsInputLabelProps;
   /** Control props. */
@@ -100,6 +102,7 @@ export interface TagsInputProps extends TagsInputRootProps {
  */
 const TagsInput = ({
   label,
+  clearTrigger = <Button variant="outline">Clear</Button>,
   labelProps,
   controlProps,
   itemProps,
@@ -151,9 +154,11 @@ const TagsInput = ({
       <TagsInputInput {...inputProps} />
     </TagsInputControl>
 
-    <TagsInputClearTrigger asChild {...clearTriggerProps}>
-      <Button variant="outline">Clear</Button>
-    </TagsInputClearTrigger>
+    {clearTrigger && (
+      <TagsInputClearTrigger asChild {...clearTriggerProps}>
+        {clearTrigger}
+      </TagsInputClearTrigger>
+    )}
   </TagsInputRoot>
 );
 


### PR DESCRIPTION
## Description

##### Task link: N/A

- Removed close trigger wrapper on `Drawer` and `Popover`
- Allow overriding `TagsInput` clear trigger render

## Test Steps

- Test `Drawer` and `Popover` close trigger composition
- Tets `TagsInput` clear trigger composition
