### PR TITLE
Set `Combobox` multiple selection input value

### DIFF
--- a/.changeset/fluffy-bananas-sniff.md
+++ b/.changeset/fluffy-bananas-sniff.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Set `Combobox` input field value when `multiple` prop is enabled

--- a/src/components/core/Combobox/Combobox.stories.tsx
+++ b/src/components/core/Combobox/Combobox.stories.tsx
@@ -36,6 +36,16 @@ export const Default: Story = {
 };
 
 /**
+ * Selection of multiple items is made possible by enabling the `multiple` prop.
+ */
+export const Multiple: Story = {
+  args: {
+    ...Default.args,
+    multiple: true,
+  },
+};
+
+/**
  * The input field and group labels can be hidden by setting the `displayFieldLabel` and `displayGroupLabel` props to `false`, respectively.
  */
 export const HideLabels: Story = {

--- a/src/components/core/Combobox/Combobox.tsx
+++ b/src/components/core/Combobox/Combobox.tsx
@@ -8,7 +8,10 @@ import { styled } from "generated/panda/jsx";
 import { combobox } from "generated/panda/recipes";
 import { createStyleContext } from "lib/util";
 
-import type { ComboboxInputValueChangeDetails } from "@ark-ui/react/combobox";
+import type {
+  ComboboxInputValueChangeDetails,
+  ComboboxValueChangeDetails,
+} from "@ark-ui/react/combobox";
 import type { ComboboxVariantProps } from "generated/panda/recipes";
 import type { ColorPalette } from "generated/panda/tokens";
 import type { AssignJSXStyleProps } from "lib/types";
@@ -144,6 +147,7 @@ const Combobox = ({
   label,
   items,
   onInputValueChange,
+  onValueChange,
   labelProps,
   controlProps,
   inputProps,
@@ -158,12 +162,13 @@ const Combobox = ({
   itemIndicatorProps,
   ...rest
 }: ComboboxProps) => {
-  const [filteredItems, setFilteredItems] = useState(items);
+  const [filteredItems, setFilteredItems] = useState(items),
+    [inputValue, setInputValue] = useState("");
 
   /**
    * Handle input value change. Composes a custom `onInputValueChange` handler, if provided.
    */
-  const handleChange = (
+  const handleInputValueChange = (
     evt: ComboboxInputValueChangeDetails,
     onInputValueChange?: ComboboxProps["onInputValueChange"],
   ) => {
@@ -178,13 +183,32 @@ const Combobox = ({
     onInputValueChange?.(evt);
   };
 
+  /**
+   * Handle value change. Composes a custom `onValueChange` handler, if provided.
+   */
+  const handleValueChange = (
+    evt: ComboboxValueChangeDetails,
+    onValueChange?: ComboboxProps["onValueChange"],
+  ) => {
+    setInputValue(evt.items.map((item) => item.label).join(", "));
+
+    // execute custom `onValueChange` handler, if provided
+    onValueChange?.(evt);
+  };
+
   return (
     <ComboboxRoot
       onInputValueChange={(evt) =>
         onInputValueChange
           ? // compose custom `onInputValueChange` handler
-            handleChange(evt, onInputValueChange)
-          : handleChange(evt)
+            handleInputValueChange(evt, onInputValueChange)
+          : handleInputValueChange(evt)
+      }
+      onValueChange={(evt) =>
+        onValueChange
+          ? // compose custom `onValueChange` handler
+            handleValueChange(evt, onValueChange)
+          : handleValueChange(evt)
       }
       items={filteredItems}
       {...rest}
@@ -194,7 +218,7 @@ const Combobox = ({
       )}
 
       <ComboboxControl {...controlProps}>
-        <ComboboxInput asChild {...inputProps}>
+        <ComboboxInput asChild value={inputValue} {...inputProps}>
           <Input colorPalette={colorPalette} />
         </ComboboxInput>
 

--- a/src/lib/theme/extensions/tokens/colors.tokens.ts
+++ b/src/lib/theme/extensions/tokens/colors.tokens.ts
@@ -131,12 +131,12 @@ export const omniColors: Tokens["colors"] = {
  * Brand colors.
  */
 export const brandColors: Tokens["colors"] = {
-  primary: omniColors.labradorite,
-  secondary: omniColors.amethyst,
-  tertiary: omniColors.emerald,
-  quaternary: omniColors.citrine,
-  quinary: omniColors.ruby,
-  senary: omniColors.sapphire,
+  primary: omniColors["labradorite"],
+  secondary: omniColors["amethyst"],
+  tertiary: omniColors["emerald"],
+  quaternary: omniColors["citrine"],
+  quinary: omniColors["ruby"],
+  senary: omniColors["sapphire"],
 };
 
 /**


### PR DESCRIPTION
## Description

##### Task link: N/A

- Set `Combobox` input field value when `multiple` prop is enabled (previously, would be blank)
- Added `Combobox` `multiple` story

## Test Steps

- With the `multiple` prop enabled on `Combobox`, make sure the input value displays the selection