### PR TITLE
Initiate `Combobox` input value with root default value

### DIFF
--- a/.changeset/witty-mice-guess.md
+++ b/.changeset/witty-mice-guess.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Initiate `Combobox` input value with `Combobox` root default value, if supplied

--- a/src/components/core/Combobox/Combobox.tsx
+++ b/src/components/core/Combobox/Combobox.tsx
@@ -163,7 +163,7 @@ const Combobox = ({
   ...rest
 }: ComboboxProps) => {
   const [filteredItems, setFilteredItems] = useState(items),
-    [inputValue, setInputValue] = useState("");
+    [inputValue, setInputValue] = useState(rest.defaultValue || "");
 
   /**
    * Handle input value change. Composes a custom `onInputValueChange` handler, if provided.


### PR DESCRIPTION
## Description

##### Task link: N/A

- Initiate `Combobox` input value with `Combobox` root default value, if supplied
  - Previously, the value was always set to initialize with `""` so would override any passed default value
 
## Test Steps

- Make sure `Combobox` accepts and displays a default value in the input field component part