### PR TITLE
Fix `Combobox` input mixing controlled and uncontrolled state

### DIFF
--- a/.changeset/tame-pumas-buy.md
+++ b/.changeset/tame-pumas-buy.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Fix `Combobox` input mixing controlled and uncontrolled state

--- a/src/components/core/Combobox/Combobox.tsx
+++ b/src/components/core/Combobox/Combobox.tsx
@@ -163,7 +163,9 @@ const Combobox = ({
   ...rest
 }: ComboboxProps) => {
   const [filteredItems, setFilteredItems] = useState(items),
-    [inputValue, setInputValue] = useState(rest.defaultValue || "");
+    [defaultInputValue, setDefaultInputValue] = useState(
+      rest.defaultValue || "",
+    );
 
   /**
    * Handle input value change. Composes a custom `onInputValueChange` handler, if provided.
@@ -190,7 +192,7 @@ const Combobox = ({
     evt: ComboboxValueChangeDetails,
     onValueChange?: ComboboxProps["onValueChange"],
   ) => {
-    setInputValue(evt.items.map((item) => item.label).join(", "));
+    setDefaultInputValue(evt.items.map((item) => item.label).join(", "));
 
     // execute custom `onValueChange` handler, if provided
     onValueChange?.(evt);
@@ -218,7 +220,7 @@ const Combobox = ({
       )}
 
       <ComboboxControl {...controlProps}>
-        <ComboboxInput asChild value={inputValue} {...inputProps}>
+        <ComboboxInput asChild defaultValue={defaultInputValue} {...inputProps}>
           <Input colorPalette={colorPalette} />
         </ComboboxInput>
 


### PR DESCRIPTION
## Description

##### Task link: N/A

- Fix `Combobox` input mixing controlled and uncontrolled state (`value` and `defaultValue`)

## Test Steps

- Make sure a rendered `Combobox` does not throw a console error about (un)controlled state mixing