### PR TITLE
Update `Tooltip` exposed props

### DIFF
--- a/.changeset/light-turkeys-grow.md
+++ b/.changeset/light-turkeys-grow.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Add `triggerProps` to `Tooltip` component

--- a/.changeset/sweet-cats-refuse.md
+++ b/.changeset/sweet-cats-refuse.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Add `positionerProps` to `Tooltip` component

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -58,6 +58,8 @@ export interface TooltipProps extends TooltipRootProps {
   arrowProps?: TooltipArrowProps;
   /** Tooltip arrow tip props. */
   arrowTipProps?: TooltipArrowTipProps;
+  /** Tooltip trigger props. */
+  triggerProps?: TooltipTriggerProps;
 }
 
 /**
@@ -70,10 +72,11 @@ const Tooltip = ({
   contentProps,
   arrowProps,
   arrowTipProps,
+  triggerProps,
   ...rest
 }: TooltipProps) => (
   <TooltipRoot openDelay={0} closeDelay={100} {...rest}>
-    {trigger && <TooltipTrigger>{trigger}</TooltipTrigger>}
+    {trigger && <TooltipTrigger {...triggerProps}>{trigger}</TooltipTrigger>}
 
     <TooltipPositioner>
       <TooltipContent {...contentProps}>

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -60,6 +60,8 @@ export interface TooltipProps extends TooltipRootProps {
   arrowTipProps?: TooltipArrowTipProps;
   /** Tooltip trigger props. */
   triggerProps?: TooltipTriggerProps;
+  /** Tooltip positioner props. */
+  positionerProps?: TooltipPositionerProps;
 }
 
 /**
@@ -73,12 +75,13 @@ const Tooltip = ({
   arrowProps,
   arrowTipProps,
   triggerProps,
+  positionerProps,
   ...rest
 }: TooltipProps) => (
   <TooltipRoot openDelay={0} closeDelay={100} {...rest}>
     {trigger && <TooltipTrigger {...triggerProps}>{trigger}</TooltipTrigger>}
 
-    <TooltipPositioner>
+    <TooltipPositioner {...positionerProps}>
       <TooltipContent {...contentProps}>
         {hasArrow && (
           <TooltipArrow {...arrowProps}>


### PR DESCRIPTION
## Description

Added `triggerProps` to the `Tooltip` component. Because the `TooltipTrigger` does not use the `asChild` prop, having access to the customize the props for the exposed `button` component is important.


## Test Steps

1) Verify that logic is sound
2) Verify that `triggerProps` work as expected
