### PR TITLE
Update `Tooltip` to use custom `Button` for trigger

### DIFF
--- a/.changeset/pink-gifts-kick.md
+++ b/.changeset/pink-gifts-kick.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Add `Button` styles to `TooltipTrigger`

--- a/src/components/core/Tooltip/Tooltip.stories.tsx
+++ b/src/components/core/Tooltip/Tooltip.stories.tsx
@@ -36,11 +36,11 @@ export const ComplexRender: Story = {
       ...Default.args!.contentProps,
       p: 4,
     },
-    trigger: (
-      <Text as="span" size="sm" fontWeight="semibold" cursor="default">
-        {app.organization.x.handle} (hover me)
-      </Text>
-    ),
+    triggerProps: {
+      variant: "ghost",
+      _hover: { bgColor: "transparent" },
+    },
+    trigger: `${app.organization.x.handle} (hover me)`,
     children: (
       <Stack gap={4} direction="row">
         <Avatar name="Childish Gambino" imageSrc="/img/donald-glover.jpg" />

--- a/src/components/core/Tooltip/Tooltip.stories.tsx
+++ b/src/components/core/Tooltip/Tooltip.stories.tsx
@@ -39,8 +39,13 @@ export const ComplexRender: Story = {
     triggerProps: {
       variant: "ghost",
       _hover: { bgColor: "transparent" },
+      cursor: "default",
     },
-    trigger: `${app.organization.x.handle} (hover me)`,
+    trigger: (
+      <Text as="span" size="sm" fontWeight="semibold">
+        {app.organization.x.handle} (hover me)
+      </Text>
+    ),
     children: (
       <Stack gap={4} direction="row">
         <Avatar name="Childish Gambino" imageSrc="/img/donald-glover.jpg" />

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -1,10 +1,14 @@
 import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
 
+import Button from "components/core/Button/Button";
 import { styled } from "generated/panda/jsx";
 import { tooltip } from "generated/panda/recipes";
 import { createStyleContext } from "lib/util";
 
-import type { TooltipVariantProps } from "generated/panda/recipes";
+import type {
+  TooltipVariantProps,
+  ButtonVariantProps,
+} from "generated/panda/recipes";
 import type { AssignJSXStyleProps } from "lib/types";
 import type { ReactNode } from "react";
 
@@ -45,7 +49,8 @@ export const TooltipTrigger = withContext(
   "trigger",
 );
 export interface TooltipTriggerProps
-  extends AssignJSXStyleProps<ArkTooltip.TriggerProps> {}
+  extends AssignJSXStyleProps<ArkTooltip.TriggerProps>,
+    ButtonVariantProps {}
 
 export interface TooltipProps extends TooltipRootProps {
   /** Tooltip trigger. */
@@ -79,7 +84,11 @@ const Tooltip = ({
   ...rest
 }: TooltipProps) => (
   <TooltipRoot openDelay={0} closeDelay={100} {...rest}>
-    {trigger && <TooltipTrigger {...triggerProps}>{trigger}</TooltipTrigger>}
+    {trigger && (
+      <TooltipTrigger {...triggerProps} asChild>
+        <Button>{trigger}</Button>
+      </TooltipTrigger>
+    )}
 
     <TooltipPositioner {...positionerProps}>
       <TooltipContent {...contentProps}>

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -49,7 +49,7 @@ export const TooltipTrigger = withContext(
   "trigger",
 );
 export interface TooltipTriggerProps
-  extends AssignJSXStyleProps<ArkTooltip.TriggerProps>,
+  extends AssignJSXStyleProps<Omit<ArkTooltip.TriggerProps, "asChild">>,
     ButtonVariantProps {}
 
 export interface TooltipProps extends TooltipRootProps {
@@ -85,7 +85,7 @@ const Tooltip = ({
 }: TooltipProps) => (
   <TooltipRoot openDelay={0} closeDelay={100} {...rest}>
     {trigger && (
-      <TooltipTrigger {...triggerProps} asChild>
+      <TooltipTrigger asChild {...triggerProps}>
         <Button>{trigger}</Button>
       </TooltipTrigger>
     )}

--- a/src/components/core/Tooltip/Tooltip.tsx
+++ b/src/components/core/Tooltip/Tooltip.tsx
@@ -6,8 +6,8 @@ import { tooltip } from "generated/panda/recipes";
 import { createStyleContext } from "lib/util";
 
 import type {
-  TooltipVariantProps,
   ButtonVariantProps,
+  TooltipVariantProps,
 } from "generated/panda/recipes";
 import type { AssignJSXStyleProps } from "lib/types";
 import type { ReactNode } from "react";


### PR DESCRIPTION
## Description

Adjusted usage for `Tooltip` to use our custom `Button` component for the trigger by default.

## Test Steps

1) Verify that logic is sound
2) Verify that rendering is appropriate

> [!NOTE]
> The default styles for `Button` are applied here, so this technically could be considered a sort of "breaking" change as downstream usage would have `Tooltip`s styled differently by default. We should discuss this. Maybe within this same PR we could add an `unstyled` variant for the `Button` and have that be applied by default for the `Tooltip`?
