### PR TITLE
Nullable `Avatar` `name` prop

### DIFF
--- a/.changeset/breezy-badgers-burn.md
+++ b/.changeset/breezy-badgers-burn.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Allow `Avatar` `name` prop to be `null`

--- a/src/components/core/Avatar/Avatar.stories.tsx
+++ b/src/components/core/Avatar/Avatar.stories.tsx
@@ -51,7 +51,7 @@ export const CustomFallback: Story = {
   },
 };
 
-const sizes = Object.keys(avatar.variants!.size) as AvatarVariant["size"][];
+const sizes = Object.keys(avatar.variants!["size"]) as AvatarVariant["size"][];
 
 // TODO make table below a reusable component for stories
 

--- a/src/components/core/Avatar/Avatar.tsx
+++ b/src/components/core/Avatar/Avatar.tsx
@@ -6,7 +6,7 @@ import { avatar } from "generated/panda/recipes";
 import { createStyleContext } from "lib/util";
 
 import type { AvatarVariantProps } from "generated/panda/recipes";
-import type { AssignJSXStyleProps } from "lib/types";
+import type { AssignJSXStyleProps, Nullable } from "lib/types";
 import type { ReactNode } from "react";
 
 const { withProvider, withContext } = createStyleContext(avatar);
@@ -49,7 +49,7 @@ const getInitials = (name: string) =>
 
 export interface AvatarProps extends AvatarRootProps {
   /** Name of user. */
-  name?: string;
+  name?: Nullable<string>;
   /** Fallback content. Defaults to user's initials if supplied, an icon otherwise. */
   fallback?: ReactNode;
   /** Image source. */

--- a/src/components/core/Menu/Menu.tsx
+++ b/src/components/core/Menu/Menu.tsx
@@ -111,9 +111,13 @@ export interface MenuTriggerItemProps
   extends AssignJSXStyleProps<ArkMenu.TriggerItemProps> {}
 
 export interface MenuProps extends MenuRootProps {
+  /** Trigger. */
   trigger?: ReactNode;
+  /** Trigger props. */
   triggerProps?: MenuTriggerProps;
+  /** Positioner props. */
   positionerProps?: MenuPositionerProps;
+  /** Content props. */
   contentProps?: MenuContentProps;
 }
 

--- a/src/lib/types/AssignJSXStyleProps.type.ts
+++ b/src/lib/types/AssignJSXStyleProps.type.ts
@@ -4,8 +4,8 @@ import type {
 } from "generated/panda/types";
 
 /**
- * Assign Panda JSX style props to component props
- * @template P Component props
+ * Assign Panda JSX style props to component props.
+ * @template P Component props.
  */
 type AssignJSXStyleProps<P> = Assign<JSXStyleProps, P>;
 

--- a/src/lib/types/Nullable.type.ts
+++ b/src/lib/types/Nullable.type.ts
@@ -1,0 +1,7 @@
+/**
+ * Container type that represents a value that can be null.
+ * @template T Type of value.
+ */
+type Nullable<T> = T | null;
+
+export default Nullable;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,1 +1,2 @@
 export type { default as AssignJSXStyleProps } from "./AssignJSXStyleProps.type";
+export type { default as Nullable } from "./Nullable.type";


### PR DESCRIPTION
## Description

##### Task link: N/A

- Fixed `Avatar` `name` prop to allow `null`

## Test Steps

Verify updated type functions properly
