### PR TITLE
Update exports for `Toaster`

### DIFF
--- a/.changeset/moody-walls-train.md
+++ b/.changeset/moody-walls-train.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Fix bundling issue for `Toaster`

--- a/src/components/core/Toaster/Toaster.tsx
+++ b/src/components/core/Toaster/Toaster.tsx
@@ -1,8 +1,4 @@
-import {
-  Toast as ArkToast,
-  Toaster as ArkToaster,
-  createToaster as arkCreateToaster,
-} from "@ark-ui/react/toast";
+import { Toast as ArkToast, Toaster as ArkToaster } from "@ark-ui/react/toast";
 import { FiX } from "react-icons/fi";
 
 import { Button } from "components/core/Button/Button";
@@ -20,7 +16,6 @@ import type { ReactNode } from "react";
 
 const { withProvider, withContext } = createStyleContext(toastRecipe);
 
-export const createToaster = arkCreateToaster;
 export interface CreateToasterProps extends ArkCreateToasterProps {}
 
 export const ToastRoot = withProvider(styled(ArkToast.Root), "root");


### PR DESCRIPTION
## Description

`Toaster` was exporting an alias for `createToaster` from Ark UI, however we now require these functions to be imported directly from Ark UI in downstream apps as it a peer dependency.

## Test Steps

1) Verify that build works as expected and `.d.ts` files are appropriately bundled
