### PR TITLE
Alert children

### DIFF
--- a/.changeset/stupid-toes-rest.md
+++ b/.changeset/stupid-toes-rest.md
@@ -1,0 +1,5 @@
+---
+"@omnidev/sigil": patch
+---
+
+Improve `Alert` styles when title is not passed, make description optional, and allow passing children which render below title and description

--- a/src/components/core/Alert/Alert.stories.tsx
+++ b/src/components/core/Alert/Alert.stories.tsx
@@ -1,6 +1,6 @@
 import { FiDownload } from "react-icons/fi";
 
-import { Alert, Icon } from "components";
+import { Alert, Button, Icon } from "components";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -49,6 +49,40 @@ export const Success: Story = {
     variant: "success",
     title: "Success",
     description: "It was a great success!",
+  },
+};
+
+/**
+ * The title is optional.
+ */
+export const NoTitle: Story = {
+  args: {
+    title: undefined,
+    description: "No title, but the description says it all! ✍️",
+  },
+};
+
+/**
+ * The description is optional.
+ */
+export const NoDescription: Story = {
+  args: {
+    title: "Riding the title wave 🌊",
+    description: undefined,
+  },
+};
+
+/**
+ * Children can be passed, and will be displayed underneath the title and description, if present.
+ */
+export const Children: Story = {
+  args: {
+    ...Default.args,
+    children: (
+      <Button variant="outline" w="fit" size="xs" mt={2}>
+        Download
+      </Button>
+    ),
   },
 };
 

--- a/src/components/core/Alert/Alert.tsx
+++ b/src/components/core/Alert/Alert.tsx
@@ -37,14 +37,13 @@ export interface AlertTitleProps
   extends AssignJSXStyleProps<ComponentProps<typeof AlertTitle>> {}
 
 export interface AlertProps extends AlertRootProps {
-  description: ReactNode;
+  description?: ReactNode;
   icon?: ReactNode;
   contentProps?: AlertContentProps;
   titleProps?: AlertTitleProps;
   descriptionProps?: AlertDescriptionProps;
 }
 
-// TODO better styles (mainly spacing) for if just description or title is passed
 // TODO default titles for each variant
 
 /**
@@ -54,6 +53,7 @@ export const Alert = ({
   title,
   description,
   icon,
+  children,
   contentProps,
   titleProps,
   descriptionProps,
@@ -71,9 +71,15 @@ export const Alert = ({
       {(icon || _icon) && <AlertIcon asChild>{icon || _icon}</AlertIcon>}
 
       <AlertContent {...contentProps}>
-        <AlertTitle {...titleProps}>{title}</AlertTitle>
+        {title && <AlertTitle {...titleProps}>{title}</AlertTitle>}
 
-        <AlertDescription {...descriptionProps}>{description}</AlertDescription>
+        {description && (
+          <AlertDescription {...descriptionProps}>
+            {description}
+          </AlertDescription>
+        )}
+
+        {children}
       </AlertContent>
     </AlertRoot>
   );


### PR DESCRIPTION
## Description

##### Task link: N/A

- Made Alert `description` prop optional
- Allowed children to be passed (rendered below title/description if passed)
- Added Alert stories

## Test Steps

- Verify Alert changes look good and passing children works well